### PR TITLE
Add text-properties in read-only buffers.

### DIFF
--- a/uimage.el
+++ b/uimage.el
@@ -155,7 +155,8 @@ Examples of image filename patterns to match:
 
 (defun uimage-display-inline-images-callback (status start end ori-buffer &optional guessed-image-type)
   (unwind-protect
-	  (let (file-data)
+      (let ((file-data)
+            (inhibit-read-only t))
 		(goto-char (point-min))
 		(search-forward-regexp "^$")
 		(unless (= (point) (point-max))


### PR DESCRIPTION
By default, `Info-mode` enables `read-only-mode`, which forbids us from
adding or changing text properties. This can be overridden by
temporarily setting `inhibit-read-only` to a non-nil value.
